### PR TITLE
增加xredis对zadd命令的测试方法

### DIFF
--- a/test/xredis-test.cpp
+++ b/test/xredis-test.cpp
@@ -409,14 +409,14 @@ int main(int argc, char **argv)
     xClient.Init(3);
 
     RedisNode RedisList1[3] = {
-        {0, "127.0.0.1", 6379, "c98359d7fa7d45595662c3255d1e8493", 2, 5, 0},
-        {1, "127.0.0.1", 6379, "c98359d7fa7d45595662c3255d1e8493", 2, 5, 0},
-        {2, "127.0.0.1", 6379, "c98359d7fa7d45595662c3255d1e8493", 2, 5, 0}
+        {0, "127.0.0.1", 6379, "", 2, 5, 0},
+        {1, "127.0.0.1", 6379, "", 2, 5, 0},
+        {2, "127.0.0.1", 6379, "", 2, 5, 0}
     };
 
     xClient.ConnectRedisCache(RedisList1, 3, CACHE_TYPE_1);
 
-    test_zadd("sort_test_key", "wwww for sorted nginx value");
+    test_zadd("test:sorted:key", "sorted value hello xredis");
     test_set("test", "wwww");
     test_get();
     test_getrange();

--- a/test/xredis-test.cpp
+++ b/test/xredis-test.cpp
@@ -4,6 +4,7 @@
 
 #include "xRedisClient.h"
 
+#define CACHE_TYPE_1 1
 xRedisClient xClient;
 
 // AP Hash Function
@@ -23,10 +24,25 @@ unsigned int APHash(const char *str)
     return (hash & 0x7FFFFFFF);
 }
 
-#define CACHE_TYPE_1 1
 
-
-
+void test_zadd(const char *charkey, const std::string& strValue)
+{
+    std::string strkey=charkey;
+    VALUES vVal;
+    int64_t retVal=0;
+    int64_t scores = 168;
+    vVal.push_back(toString(scores));
+    vVal.push_back(strValue);
+    RedisDBIdx dbi(&xClient);
+    bool bRet = dbi.CreateDBIndex(charkey, APHash, CACHE_TYPE_1);
+    if (bRet) {
+        if (xClient.zadd(dbi, strkey, vVal, retVal)) {
+            printf("%s success \r\n", __PRETTY_FUNCTION__);
+        } else {
+            printf("%s error [%s] \r\n", __PRETTY_FUNCTION__, dbi.GetErrInfo());
+        }
+    }
+}
 
 void test_set(const char *strkey, const char *strValue)
 {
@@ -393,13 +409,14 @@ int main(int argc, char **argv)
     xClient.Init(3);
 
     RedisNode RedisList1[3] = {
-        {0, "127.0.0.1", 6379, "", 2, 5, 0},
-        {1, "127.0.0.1", 6379, "", 2, 5, 0},
-        {2, "127.0.0.1", 6379, "", 2, 5, 0}
+        {0, "127.0.0.1", 6379, "c98359d7fa7d45595662c3255d1e8493", 2, 5, 0},
+        {1, "127.0.0.1", 6379, "c98359d7fa7d45595662c3255d1e8493", 2, 5, 0},
+        {2, "127.0.0.1", 6379, "c98359d7fa7d45595662c3255d1e8493", 2, 5, 0}
     };
 
     xClient.ConnectRedisCache(RedisList1, 3, CACHE_TYPE_1);
 
+    test_zadd("sort_test_key", "wwww for sorted nginx value");
     test_set("test", "wwww");
     test_get();
     test_getrange();


### PR DESCRIPTION
zadd方法的第四个参数仅做返回值用，score需要提前存储到数据中