### PR TITLE
fix setex commandargv_bool error

### DIFF
--- a/src/xRedisClient_strings.cpp
+++ b/src/xRedisClient_strings.cpp
@@ -76,7 +76,7 @@ bool xRedisClient::mget(const DBIArray &vdbi,   const KEYS &  keys, ReplyData& v
     if (n!=keys.size()) {
         return bRet;
     }
-    
+
     DataItem item;
     DBIArray::const_iterator iter_dbi = vdbi.begin();
     KEYS::const_iterator iter_key = keys.begin();
@@ -120,7 +120,7 @@ bool xRedisClient::setex(const RedisDBIdx& dbi,    const string& key,  int secon
     vCmdData.push_back(toString(seconds));
     vCmdData.push_back(value);
     SETDEFAULTIOTYPE(MASTER);
-    return commandargv_bool(dbi, vCmdData);
+    return commandargv_status(dbi, vCmdData);
 }
 
 bool xRedisClient::setnx(const RedisDBIdx& dbi,  const string& key,  const string& value) {
@@ -190,7 +190,7 @@ bool xRedisClient::bitpos(const RedisDBIdx& dbi, const string& key, int bit, int
     SETDEFAULTIOTYPE(SLAVE);
     if ( (start!=0)||(end!=0) ) {
         return command_integer(dbi, pos, "BITPOS %s %d %d %d", key.c_str(), bit, start, end);
-    } 
+    }
     return command_integer(dbi, pos, "BITPOS %s %d", key.c_str(), bit);
 }
 


### PR DESCRIPTION
commit id: a61beb0
description: the function '**setex**' in **xRedisClient_strings**.cpp checks wrong reply type

when invoke function '**setex**', if it is ok, this function actually returns reply which _reply->type_ is "_REDIS_REPLY_STATUS_" and _reply->str_ is "_OK_".
in current implement, '**setex**' checks _reply->ingeter_ which is always 0.
so commandargv_status should be used.