### PR TITLE
Update xRedisClient.cpp

### DIFF
--- a/src/xRedisClient.cpp
+++ b/src/xRedisClient.cpp
@@ -408,7 +408,7 @@ int32_t xRedisClient::GetReply(xRedisContext* ctx, ReplyData& vData)
 {
     //vData.clear();
     //ReplyData(vData).swap(vData);
-    redisReply *reply;
+    redisReply *reply = NULL;
     RedisConn *pRedisConn = static_cast<RedisConn *>(ctx->conn);
     int32_t ret = redisGetReply(pRedisConn->getCtx(), (void**)&reply);
     if (0==ret) {


### PR DESCRIPTION
这个地方应该初始化一下。实际上getReply失败的话，这个指针是应该为空的，但是由于未初始化的原因，导致该指针有个初始值，满足了释放的条件，却又在实际释放的时候会导致段错误